### PR TITLE
basic debugdevice support (OpenMSX)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ FILES  = msxbios.blk t-sc2.blk t-delay.blk
 FILES += v9990.blk t-v9990.blk
 FILES += msxdos.blk t-msxdos.blk
 FILES += jed.blk flash.blk nesman.blk
-FILES += vt52.blk grp.blk
+FILES += vt52.blk grp.blk debug.blk
 
 DIST_DIR=dist
 CC=gcc

--- a/compile.tcl
+++ b/compile.tcl
@@ -1,4 +1,4 @@
-set blk_files [list msxbios.blk vt52.blk grp.blk]
+set blk_files [list msxbios.blk vt52.blk grp.blk debug.blk]
 
 #
 # Wait for boot message "BOOT COMPLETED"
@@ -126,6 +126,11 @@ diska forth.dsk
 set save_settings_on_exit off
 set speed 9999
 set fullspeedwhenloading on
+
+# Debug
+ext debugdevice
+set debugoutput stdout
+#debug set_watchpoint write_io {0x2f} {} {message "$::wp_last_value received from debugdevice"}
 
 message "Detecting boot..."
 wait_boot call_forth83

--- a/src/debug.4th
+++ b/src/debug.4th
@@ -1,0 +1,32 @@
+\ debugdevice
+
+----
+
+decimal 2 capacity 1- thru
+
+----
+hex code _debugmode ( byte -- )
+   E1 C,              \ POP HL
+   7D C,              \ LD A, L
+   D3 C, 2E C,        \ OUT 2E, A
+   next
+end-code
+
+: debugmode cr ." Sending byte " dup . ." to debug device at #2e..." _debugmode ;
+
+----
+hex code _debug ( byte -- )
+   E1 C,              \ POP HL
+   7D C,              \ LD A, L
+   D3 C, 2F C,        \ OUT 2F, A
+   next
+end-code
+
+: debugc cr ." Sending " dup emit ."  to debug device at #2f..." _debug ;
+
+----
+decimal
+
+: debugtest
+   31 debugmode \ set debugdevice to verbose mode
+   65 debugc ;  \ prints A to stdout


### PR DESCRIPTION
Support for OpenMSX' debugdevice will make it easier to test assembly code and if certain paths were executed.