### PR TITLE
z80 opcode EI not being processed

### DIFF
--- a/src/debug.4th
+++ b/src/debug.4th
@@ -15,14 +15,14 @@ end-code
 : debugmode cr ." Sending byte " dup . ." to debug device at #2e..." _debugmode ;
 
 ----
-hex code _debug ( byte -- )
+hex code _debugc ( byte -- )
    E1 C,              \ POP HL
    7D C,              \ LD A, L
    D3 C, 2F C,        \ OUT 2F, A
    next
 end-code
 
-: debugc cr ." Sending " dup emit ."  to debug device at #2f..." _debug ;
+: debugc cr ." Sending " dup emit ."  to debug device at #2f..." _debugc ;
 
 ----
 decimal

--- a/src/msxbios.4th
+++ b/src/msxbios.4th
@@ -21,7 +21,7 @@ hex
    DD c, 21 c, ,       \ LD IX,fn
    FD c, 2A c, FCC0 ,  \ LD IY,[FCC0]
    CD c, 1C ,          \ CALL CALSLT
-   FB                  \ EI
+   FB c,               \ EI
 ;
 ----
 
@@ -326,7 +326,7 @@ hex FC9E constant #JIFFY
 
 : (delayjf) ( jiffy-min -- )
   begin
-    dup #JIFFY @ u<=  \ unisgned compare
+    dup #JIFFY @ u<=  \ unsigned compare
   until drop ;
 ----
 \ delayjiffy ( u -- )


### PR DESCRIPTION
after `open msxbios.blk` and `OK`, lots of `0xFB` (the opcode of the `EI` instruction) were found on the stack because of a missing coma.