### PR TITLE
DELETE_ON_ERROR target removes .blk file on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ BLKS=$(addprefix $(DIST_DIR)/, $(FILES))
 vpath %.4th src
 vpath %.c src
 
-.PHONY : all
+.PHONY : all .DELETE_ON_ERROR
 all: $(CONVBLK) $(BLKS)
 
 $(DIST_DIR)/%.blk: %.4th


### PR DESCRIPTION
If compilation fails, no `.blk` file will be generated. Before this patch, an incomplete `.blk` would still be used if make was executed a second time.